### PR TITLE
Refactor(#1): OAuth 플랫폼 구별방식 리팩토링

### DIFF
--- a/src/main/java/com/jaejoo/fitdo/domain/auth/service/domain/ImportManager.java
+++ b/src/main/java/com/jaejoo/fitdo/domain/auth/service/domain/ImportManager.java
@@ -6,24 +6,22 @@ import com.jaejoo.fitdo.global.client.res.OAuthUserDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 import static com.jaejoo.fitdo.domain.auth.service.application.req.AuthType.KAKAO;
 
 @Component
 @RequiredArgsConstructor
 public class ImportManager {
-    private final OAuthDateImporter kakaoImporter;
+    private final List<OAuthDateImporter> importers;
 
     public OAuthUserDate importData(String authorizationToken, AuthType platform) {
-        OAuthUserDate oAuthUserDate = null;
-        if (isKAKAO(platform)) {
-            oAuthUserDate = kakaoImporter.getData(authorizationToken);
-        } else {
-            throw new IllegalArgumentException("지원하지 않는 플랫폼입니다.");
+        for (OAuthDateImporter importer : importers) {
+            if (!importer.isSupport(platform)) {
+                continue;
+            }
+            return importer.getData(authorizationToken);
         }
-        return oAuthUserDate;
-    }
-
-    private static boolean isKAKAO(AuthType platform) {
-        return platform.equals(KAKAO);
+        throw new IllegalArgumentException("지원하지 않는 플랫폼입니다.");
     }
 }

--- a/src/main/java/com/jaejoo/fitdo/global/client/OAuthDateImporter.java
+++ b/src/main/java/com/jaejoo/fitdo/global/client/OAuthDateImporter.java
@@ -1,7 +1,10 @@
 package com.jaejoo.fitdo.global.client;
 
+import com.jaejoo.fitdo.domain.auth.service.application.req.AuthType;
 import com.jaejoo.fitdo.global.client.res.OAuthUserDate;
 
 public interface OAuthDateImporter {
     OAuthUserDate getData(String token);
+
+    Boolean isSupport(AuthType authType);
 }

--- a/src/main/java/com/jaejoo/fitdo/global/client/impl/KakaoImporter.java
+++ b/src/main/java/com/jaejoo/fitdo/global/client/impl/KakaoImporter.java
@@ -1,5 +1,6 @@
 package com.jaejoo.fitdo.global.client.impl;
 
+import com.jaejoo.fitdo.domain.auth.service.application.req.AuthType;
 import com.jaejoo.fitdo.global.client.OAuthDateImporter;
 import com.jaejoo.fitdo.global.client.res.OAuthUserDate;
 import org.springframework.http.MediaType;
@@ -28,5 +29,13 @@ public class KakaoImporter implements OAuthDateImporter {
                 .retrieve()
                 .bodyToMono(KakaoUserResponseDto.class)
                 .block().toCommonDto();
+    }
+
+    @Override
+    public Boolean isSupport(AuthType authType) {
+        if (authType.equals(AuthType.KAKAO)) {
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 기존의 로그인 if문으로 플랫폼 구현체를 구별하는 방식에서 빈 주입방식으로 리팩토링

<br/>

## ➕ 이슈 링크

- #1 

<br/>