### PR TITLE
[Fix(#21)] 운동목록 삭제 방식 변경

### DIFF
--- a/src/main/java/com/jaejoo/fitdo/domain/exercise/infra/repository/ExerciseQueryRepository.java
+++ b/src/main/java/com/jaejoo/fitdo/domain/exercise/infra/repository/ExerciseQueryRepository.java
@@ -4,7 +4,10 @@ import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.entity.CategoryJpaE
 import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.entity.ExerciseJpaEntity;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ExerciseQueryRepository {
     List<ExerciseJpaEntity> findExercisesByCategory(CategoryJpaEntity category);
+
+    ExerciseJpaEntity findById(Long exerciseId);
 }

--- a/src/main/java/com/jaejoo/fitdo/domain/exercise/infra/repository/impl/ExerciseQueryJpaRepository.java
+++ b/src/main/java/com/jaejoo/fitdo/domain/exercise/infra/repository/impl/ExerciseQueryJpaRepository.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -17,5 +18,10 @@ public class ExerciseQueryJpaRepository implements ExerciseQueryRepository {
     @Override
     public List<ExerciseJpaEntity> findExercisesByCategory(CategoryJpaEntity category) {
         return List.of();
+    }
+
+    @Override
+    public ExerciseJpaEntity findById(Long exerciseId) {
+        return repository.findById(exerciseId).orElseThrow(()->new IllegalArgumentException("not found entity"));
     }
 }

--- a/src/main/java/com/jaejoo/fitdo/domain/exercise/infra/repository/jpa/entity/DeleteDelimiter.java
+++ b/src/main/java/com/jaejoo/fitdo/domain/exercise/infra/repository/jpa/entity/DeleteDelimiter.java
@@ -1,0 +1,5 @@
+package com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.entity;
+
+public enum DeleteDelimiter {
+    DELETE,IN_USER;
+}

--- a/src/main/java/com/jaejoo/fitdo/domain/exercise/infra/repository/jpa/entity/ExerciseJpaEntity.java
+++ b/src/main/java/com/jaejoo/fitdo/domain/exercise/infra/repository/jpa/entity/ExerciseJpaEntity.java
@@ -14,13 +14,28 @@ public class ExerciseJpaEntity {
     private Long id;
     private String name;
 
+    @Enumerated(EnumType.STRING)
+    private DeleteDelimiter deleteDelimiter;
+
     @ManyToOne
     @JoinColumn(name = "category_id")
     private CategoryJpaEntity category;
 
     @Builder
-    public ExerciseJpaEntity(String name, CategoryJpaEntity category) {
+    public ExerciseJpaEntity(Long id, String name, DeleteDelimiter deleteDelimiter, CategoryJpaEntity category) {
+        this.id = id;
         this.name = name;
+        this.deleteDelimiter = deleteDelimiter;
         this.category = category;
+    }
+
+    public ExerciseJpaEntity(String name, CategoryJpaEntity category, DeleteDelimiter deleteDelimiter) {
+        this.name = name;
+        this.deleteDelimiter = deleteDelimiter;
+        this.category = category;
+    }
+
+    public static ExerciseJpaEntity create(String name, CategoryJpaEntity category) {
+        return new ExerciseJpaEntity(name, category, DeleteDelimiter.IN_USER);
     }
 }

--- a/src/main/java/com/jaejoo/fitdo/domain/exercise/service/application/ExerciseService.java
+++ b/src/main/java/com/jaejoo/fitdo/domain/exercise/service/application/ExerciseService.java
@@ -4,6 +4,7 @@ import com.jaejoo.fitdo.domain.exercise.infra.repository.CategoryQueryRepository
 import com.jaejoo.fitdo.domain.exercise.infra.repository.ExerciseCommandRepository;
 import com.jaejoo.fitdo.domain.exercise.infra.repository.ExerciseQueryRepository;
 import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.entity.CategoryJpaEntity;
+import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.entity.DeleteDelimiter;
 import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.entity.ExerciseJpaEntity;
 import com.jaejoo.fitdo.domain.exercise.service.application.req.ExerciseCreateCommand;
 import com.jaejoo.fitdo.domain.exercise.service.application.res.ExercisesWithinCategory;
@@ -23,9 +24,7 @@ public class ExerciseService {
 
     public String createExercise(ExerciseCreateCommand command) {
         CategoryJpaEntity categories = categoryQueryRepository.findById(command.getCategoryId());
-        ExerciseJpaEntity exerciseJpaEntity = ExerciseJpaEntity.builder().name(command.getExerciseName())
-                .category(categories)
-                .build();
+        ExerciseJpaEntity exerciseJpaEntity = ExerciseJpaEntity.create(command.getExerciseName(), categories);
         ExerciseJpaEntity save = exerciseCommandRepository.save(exerciseJpaEntity);
         return save.getName();
     }
@@ -48,7 +47,14 @@ public class ExerciseService {
         return exercisesWithCategory;
     }
 
-    public void removeExercises(Long exerciseId){
-        exerciseCommandRepository.deleteById(exerciseId);
+    public void removeExercises(Long exerciseId) {
+        ExerciseJpaEntity willRemoveEntity = exerciseQueryRepository.findById(exerciseId);
+        ExerciseJpaEntity exerciseJpaEntity = ExerciseJpaEntity.builder()
+                .category(willRemoveEntity.getCategory())
+                .name(willRemoveEntity.getName())
+                .id(willRemoveEntity.getId())
+                .deleteDelimiter(DeleteDelimiter.DELETE)
+                .build();
+        exerciseCommandRepository.save(exerciseJpaEntity);
     }
 }

--- a/src/test/java/com/jaejoo/fitdo/domain/exercise/service/application/ExerciseServiceTest.java
+++ b/src/test/java/com/jaejoo/fitdo/domain/exercise/service/application/ExerciseServiceTest.java
@@ -1,18 +1,25 @@
 package com.jaejoo.fitdo.domain.exercise.service.application;
 
+import com.jaejoo.fitdo.domain.exercise.infra.repository.RecordQueryRepository;
 import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.CategoryJpaRepository;
+import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.DailyExerciseRecordJpaRepository;
+import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.DailyRecordJpaRepository;
 import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.ExerciseJpaRepository;
 import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.entity.CategoryJpaEntity;
+import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.entity.DailyExerciseRecordJpaEntity;
+import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.entity.DailyRecordJpaEntity;
 import com.jaejoo.fitdo.domain.exercise.infra.repository.jpa.entity.ExerciseJpaEntity;
 import com.jaejoo.fitdo.domain.exercise.service.application.req.ExerciseCreateCommand;
 import com.jaejoo.fitdo.domain.exercise.service.application.res.FindExercisesWithCategory;
 import com.jaejoo.fitdo.domain.user.infra.repository.jpa.UserJpaRepository;
 import com.jaejoo.fitdo.domain.user.infra.repository.jpa.entity.UserJpaEntity;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
@@ -30,7 +37,12 @@ class ExerciseServiceTest {
     private UserJpaRepository userJpaRepository;
     @Autowired
     private ExerciseJpaRepository exerciseJpaRepository;
-
+    @Autowired
+    private DailyRecordJpaRepository dailyRecordJpaRepository;
+    @Autowired
+    private DailyExerciseRecordJpaRepository dailyExerciseRecordJpaRepository;
+    @Autowired
+    private RecordQueryRepository recordQueryRepository;
 /*    @AfterEach
     void init(){
         exerciseJpaRepository.deleteAll();
@@ -109,7 +121,7 @@ class ExerciseServiceTest {
     }
 
     @Test
-    void 운동삭제() {
+    void 운동삭제해도_완전삭제되지않음() {
         // given
         UserJpaEntity user = UserJpaEntity.builder().build();
         UserJpaEntity saveUser = userJpaRepository.save(user);
@@ -137,6 +149,44 @@ class ExerciseServiceTest {
         System.out.println("=====Logic End=====");
         // then
         List<ExerciseJpaEntity> all = exerciseJpaRepository.findAll();
-        assertThat(all.size()).isEqualTo(2);
+        assertThat(all.size()).isEqualTo(3);
+    }
+
+    @Test
+    void 운동삭제시_기록된_운동은_삭제되지않도록_soft_delete진행() {
+        // given
+        UserJpaEntity user = UserJpaEntity.builder().build();
+        UserJpaEntity saveUser = userJpaRepository.save(user);
+
+
+        CategoryJpaEntity chestCategory = CategoryJpaEntity.builder().user(saveUser).categoryName("가슴").build();
+        CategoryJpaEntity saveChestCategory = categoryJpaRepository.save(chestCategory);
+
+        CategoryJpaEntity backCategory = CategoryJpaEntity.builder().user(saveUser).categoryName("등").build();
+        CategoryJpaEntity saveBackCategory = categoryJpaRepository.save(backCategory);
+
+        ExerciseJpaEntity benchpress1 = ExerciseJpaEntity.builder().name("벤치프레스").category(saveChestCategory).build();
+        ExerciseJpaEntity flymachine1 = ExerciseJpaEntity.builder().name("플라이머신").category(saveChestCategory).build();
+        ExerciseJpaEntity deadlift1 = ExerciseJpaEntity.builder().name("데드리프트").category(saveBackCategory).build();
+
+        ExerciseJpaEntity exercise1 = exerciseJpaRepository.save(benchpress1);
+        ExerciseJpaEntity exercise2 = exerciseJpaRepository.save(flymachine1);
+        ExerciseJpaEntity exercise3 = exerciseJpaRepository.save(deadlift1);
+
+        LocalDate saveDate = LocalDate.of(2024,11,25);
+        DailyRecordJpaEntity dailyRecordJpaEntity = new DailyRecordJpaEntity(saveDate, saveUser);
+        DailyRecordJpaEntity saveDailyRecordJpaEntity = dailyRecordJpaRepository.save(dailyRecordJpaEntity);
+
+        DailyExerciseRecordJpaEntity dailyExerciseRecordJpaEntity = DailyExerciseRecordJpaEntity.builder().exercise(benchpress1).exerciseSet(1).volume(10).isProgress(false).weight(50).dailyRecord(saveDailyRecordJpaEntity).build();
+        dailyExerciseRecordJpaRepository.save(dailyExerciseRecordJpaEntity);
+        // when
+        System.out.println("=====Logic Start=====");
+
+        exerciseService.removeExercises(benchpress1.getId());
+
+        System.out.println("=====Logic End=====");
+        // then
+        List<DailyExerciseRecordJpaEntity> exerciseRecordsInDailyRecordDividedBy = recordQueryRepository.findExerciseRecordsInDailyRecordDividedBy(benchpress1, saveDailyRecordJpaEntity);
+        assertThat(exerciseRecordsInDailyRecordDividedBy.size()).isOne();
     }
 }


### PR DESCRIPTION
- 제목 : [Feat(#issue 번호)]: 기능명
  ex) [Feat(#17)]: pull request template 작성
  (확인 후 지워주세요)

<br/>

## 🔎 작업 내용

- hard delete에서 soft delete방식으로 변경
>기존 hard delete의 경우 운동목록 삭제시, 연관관계의 자식으로 걸려있는 운동기록 엔티티때문에 오류가 발생하고, 운동목록이 삭제되어도, 사용자는 이전 기록을 확인할수 있어야하기 때문에 soft delete 방식으로 삭제 방식을 변경

  <br/>

## 🔧 앞으로의 과제

- 엔티티 레벨이 아닌 도메인 레벨로 변경예정

<br/>

## ➕ 이슈 링크

- [#21](https://github.com/jaepyo-Lee/fitdo/issues/21)

<br/>